### PR TITLE
Update PR preview action version and configuration

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -104,8 +104,40 @@ jobs:
           ls _site/ || echo "_site directory not found"
           echo "contents of .:"
           ls .
+
       - name: Deploy PR Preview
-        uses: rossjrw/pr-preview-action@main
+        id: preview-step
+        if: github.event_name == 'pull_request'
+        uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: _site/
-          pages-base-url: ucdavis.github.io/win
+          source-dir: ./_site/
+          # Deploy on label changes too, not just open/reopen/synchronize
+          # The 'auto' action ignores label events, so we explicitly set 'deploy' for non-closed PRs
+          action: ${{ github.event.action == 'closed' && 'remove' || 'deploy' }}
+          preview-branch: gh-pages
+          comment: "false"
+          wait-for-pages-deployment: false
+
+      # Create sticky comment with preview link
+      # Following https://github.com/rossjrw/pr-preview-action?tab=readme-ov-file#customise-the-sticky-comment
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: steps.preview-step.outputs.deployment-action == 'deploy' && env.deployment_status == 'success'
+        with:
+          header: pr-preview
+          recreate: true
+          message: |
+              [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview-step.outputs.action-version }}
+              :---:
+              | <p><img src="https://qr.rossjrw.com/?url=${{ steps.preview-step.outputs.preview-url }}" height="100" align="right" alt="QR code for preview link"></p> :rocket: View preview at <br> ${{ steps.preview-step.outputs.preview-url }} <br><br>
+              | <h6>Built to branch [`gh-pages`](${{ github.server_url }}/${{ github.repository }}/tree/gh-pages) at ${{ steps.preview-step.outputs.action-start-time }}. <br> Preview will be ready when the [GitHub Pages deployment](${{ github.server_url }}/${{ github.repository }}/deployments) is complete. <br><br> </h6>
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: steps.preview-step.outputs.deployment-action == 'remove' && env.deployment_status == 'success'
+        with:
+            header: pr-preview
+            recreate: true
+            message: |
+                [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview-step.outputs.action-version }}
+                :---:
+                Preview removed because the pull request was closed.
+                ${{ steps.preview-step.outputs.action-start-time }}


### PR DESCRIPTION
This pull request updates the pull request preview deployment workflow to improve reliability and user feedback. The main changes are focused on better handling of PR preview deployments and providing clear, sticky comments with preview links or removal notices.

**Workflow improvements:**

* Switched the PR preview deployment action from `rossjrw/pr-preview-action@main` to the stable `@v1` release, and added the `id` and conditional execution to ensure it only runs for pull request events.
* Enhanced deployment logic to explicitly handle label changes and PR closures by setting the `action` input to either `deploy` or `remove` as appropriate.

**User feedback enhancements:**

* Added a step to create or update a sticky comment with the preview link and a QR code when a preview is deployed successfully, using `marocchino/sticky-pull-request-comment@v2`.
* Added a separate step to update the sticky comment to indicate preview removal when the PR is closed.